### PR TITLE
add containsExactly

### DIFF
--- a/src/extensions/sn_highclass/index.js
+++ b/src/extensions/sn_highclass/index.js
@@ -145,6 +145,25 @@ class HighClass {
                     }
                 },
                 {
+                    opcode: 'containsExactly',
+                        text: formatMessage({
+                            id: 'sn.blocks.containsexactly',
+                            default: '[A] contains exactly [B]?',
+                            description: 'Block that returns if one value contains the other. Case sensitive.'
+                        }),
+                        blockType: BlockType.BOOLEAN,
+                        arguments: {
+                            A: {
+                                type: ArgumentType.STRING,
+                                defaultValue: 'abc'
+                            },
+                            B: {
+                                type: ArgumentType.STRING,
+                                defaultValue: 'ABC'
+                            }
+                        }
+                },
+                {
                     opcode: 'LTE',
                     text: formatMessage({
                         id: 'sn.blocks.lte',
@@ -704,6 +723,10 @@ class HighClass {
 
     caps (args, utils) {
         return args.text.toUpperCase()
+    }
+
+    containsExactly ({A, B}) {
+        return A.indexOf(B) !== 1
     }
 
     replace (args,utils) {

--- a/src/extensions/sn_highclass/index.js
+++ b/src/extensions/sn_highclass/index.js
@@ -726,7 +726,7 @@ class HighClass {
     }
 
     containsExactly ({A, B}) {
-        return A.indexOf(B) !== 1
+        return A.contains(B)
     }
 
     replace (args,utils) {


### PR DESCRIPTION
it wasn't in there so i added it myself lol (hopefully it works)

### Resolves

Doesn't resolve anything

### Proposed Changes

Adds a new "contains exactly" block. It's like the block in the operators category except it is case sensitive.

### Reason for Changes

Because I wanted to make a word processor in SN-Edit and the only other solution I could find was on the Scratch Wiki and was still using 2.0 features.